### PR TITLE
Remove Spanish locale option

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -97,10 +97,6 @@ const config = {
   favicon: `${favicon}`,
   deploymentBranch: "gh-pages",
   staticDirectories: ["static"],
-  i18n: {
-    defaultLocale: "en",
-    locales: ["en", "es"],
-  },
   customFields: {
     startButtonTitle: `${startButtonTitle}`,
     featureList: featureList,


### PR DESCRIPTION
This PR removes the Spanish locale option in the UI.
<img width="1248" alt="Screenshot 2024-11-15 at 19 48 12" src="https://github.com/user-attachments/assets/1fbc2c8e-85c2-43ab-8a06-0ee3a16dd0bf">
